### PR TITLE
fix: filter out releases with 'server@' prefix in addition to 'app@'

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -21,13 +21,13 @@ redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|
 version=
 printf "redirect url: %s\n" "$redirect_url" >&2
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
-	# Get the latest version excluding those with 'app@' prefix
-	version="$(list_all_versions_sorted | grep -v '^app@' | tail -n1 | xargs echo)"
+	# Get the latest version excluding those with 'app@' or 'server@' prefix
+	version="$(list_all_versions_sorted | grep -E -v '^(app|server)@' | tail -n1 | xargs echo)"
 else
 	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
-	# Check if the version has 'app@' prefix and fetch an alternative version if it does
-	if [[ "$version" == app@* ]]; then
-		version="$(list_all_versions_sorted | grep -v '^app@' | tail -n1 | xargs echo)"
+	# Check if the version has 'app@' or 'server@' prefix and fetch an alternative version if it does
+	if [[ "$version" == app@* ]] || [[ "$version" == server@* ]]; then
+		version="$(list_all_versions_sorted | grep -E -v '^(app|server)@' | tail -n1 | xargs echo)"
 	fi
 fi
 


### PR DESCRIPTION
I noted the detection of the latest Tuist version via the Mise plugin was failing. It turns out, our logic was filtering out `app@` tags, but not `server@` ones, causing the installation of `latest` to fail.

## Summary (Claude)
- Updated the `latest-stable` script to exclude both `app@` and `server@` prefixed versions
- Changed grep commands to use extended regex pattern `'^(app|server)@'`
- Updated the conditional check to handle both prefixes
