### PR TITLE
Ignore cache@ tags along with app@ and server@

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -21,13 +21,13 @@ redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|
 version=
 printf "redirect url: %s\n" "$redirect_url" >&2
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
-	# Get the latest version excluding those with 'app@' or 'server@' prefix
-	version="$(list_all_versions_sorted | grep -E -v '^(app|server)@' | tail -n1 | xargs echo)"
+	# Get the latest version excluding those with '{foo}@{version}' prefix
+	version="$(list_all_versions_sorted | grep -E -v '^[^@]+@' | tail -n1 | xargs echo)"
 else
 	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
-	# Check if the version has 'app@' or 'server@' prefix and fetch an alternative version if it does
-	if [[ "$version" == app@* ]] || [[ "$version" == server@* ]]; then
-		version="$(list_all_versions_sorted | grep -E -v '^(app|server)@' | tail -n1 | xargs echo)"
+	# Check if the version has a '{foo}@{version}' prefix and fetch an alternative version if it does
+	if [[ "$version" == *@* ]]; then
+		version="$(list_all_versions_sorted | grep -E -v '^[^@]+@' | tail -n1 | xargs echo)"
 	fi
 fi
 


### PR DESCRIPTION
We have a new non-CLI release which needs its tags ignored similarly to `app` and `server`.